### PR TITLE
Add a feature that sets a target path

### DIFF
--- a/textlint-server/src/server.ts
+++ b/textlint-server/src/server.ts
@@ -12,6 +12,7 @@ import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
 import * as glob from "glob";
+import * as minimatch from "minimatch";
 
 import {
     NoConfigNotification, NoLibraryNotification, ExitNotification,
@@ -169,7 +170,11 @@ function findConfig(): string {
 function validate(doc: TextDocument): Thenable<void> {
     let uri = doc.uri;
     TRACE(`validate ${uri}`);
-    if (!textlintModule || uri.startsWith("file:") === false) {
+    let currentFile = doc.uri.replace("file://" + workspaceRoot + "/", "");
+    let isTarget = (settings.targetPath === "" || minimatch(currentFile, settings.targetPath, {
+        matchBase: true
+    }));
+    if (!textlintModule || uri.startsWith("file:") === false || !isTarget) {
         TRACE("validation skiped...");
         return Promise.resolve();
     }

--- a/textlint/package-lock.json
+++ b/textlint/package-lock.json
@@ -11,147 +11,34 @@
         "vscode-languageserver": "^5.3.0-next.1"
       },
       "dependencies": {
-        "@types/events": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "@types/glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "requires": {
-            "@types/events": "*",
-            "@types/minimatch": "*",
-            "@types/node": "*"
-          }
-        },
-        "@types/minimatch": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "@types/node": {
-          "version": "11.11.3",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            }
-          }
-        },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "bundled": true,
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "bundled": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "bundled": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "commander": {
-          "version": "2.19.0",
-          "bundled": true
-        },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
-        },
-        "diff": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "glob": {
-          "version": "7.1.3",
-          "bundled": true,
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -161,160 +48,78 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true
-        },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "js-yaml": {
-          "version": "3.12.1",
-          "bundled": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.6.0",
-          "bundled": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "bundled": true
-        },
-        "tslint": {
-          "version": "5.12.1",
-          "bundled": true,
-          "requires": {
-            "babel-code-frame": "^6.22.0",
-            "builtin-modules": "^1.1.1",
-            "chalk": "^2.3.0",
-            "commander": "^2.12.1",
-            "diff": "^3.2.0",
-            "glob": "^7.1.1",
-            "js-yaml": "^3.7.0",
-            "minimatch": "^3.0.4",
-            "resolve": "^1.3.2",
-            "semver": "^5.3.0",
-            "tslib": "^1.8.0",
-            "tsutils": "^2.27.2"
-          }
-        },
-        "tsutils": {
-          "version": "2.29.0",
-          "bundled": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        },
-        "typescript": {
-          "version": "3.3.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "vscode-jsonrpc": {
-          "version": "4.0.0",
-          "bundled": true
+          "version": "5.0.0-next.2",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.0-next.2.tgz",
+          "integrity": "sha512-Q3/jabZUNviCG9hhF6hHWjhrABevPF9mv0aiE2j8BYCAP2k+aHTpjMyk+04MzaAqWYwXdQuZkLSbcYCCqbzJLg=="
         },
         "vscode-languageserver": {
-          "version": "5.3.0-next.1",
-          "bundled": true,
+          "version": "5.3.0-next.10",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.3.0-next.10.tgz",
+          "integrity": "sha512-QL7Fe1FT6PdLtVzwJeZ78pTic4eZbzLRy7yAQgPb9xalqqgZESR0+yDZPwJrM3E7PzOmwHBceYcJR54eQZ7Kng==",
           "requires": {
-            "vscode-languageserver-protocol": "3.15.0-next.1",
-            "vscode-uri": "^1.0.6"
+            "vscode-languageserver-protocol": "^3.15.0-next.8",
+            "vscode-textbuffer": "^1.0.0"
           }
         },
         "vscode-languageserver-protocol": {
-          "version": "3.15.0-next.1",
-          "bundled": true,
+          "version": "3.15.0-next.9",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.9.tgz",
+          "integrity": "sha512-b9PAxouMmtsLEe8ZjbIMPb7wRWPhckGfgjwZLmp/dWnaAuRPYtY3lGO0/rNbLc3jKIqCVlnEyYVFKalzDAzj0g==",
           "requires": {
-            "vscode-jsonrpc": "^4.0.0",
-            "vscode-languageserver-types": "3.14.0"
+            "vscode-jsonrpc": "^5.0.0-next.2",
+            "vscode-languageserver-types": "^3.15.0-next.5"
           }
         },
         "vscode-languageserver-types": {
-          "version": "3.14.0",
-          "bundled": true
+          "version": "3.15.0-next.5",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.5.tgz",
+          "integrity": "sha512-7hrELhTeWieUgex3+6692KjCkcmO/+V/bFItM5MHGcBotzwmjEuXjapLLYTYhIspuJ1ibRSik5MhX5YwLpsPiw=="
         },
-        "vscode-uri": {
-          "version": "1.0.6",
-          "bundled": true
+        "vscode-textbuffer": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vscode-textbuffer/-/vscode-textbuffer-1.0.0.tgz",
+          "integrity": "sha512-zPaHo4urgpwsm+PrJWfNakolRpryNja18SUip/qIIsfhuEqEIPEXMxHOlFPjvDC4JgTaimkncNW7UMXRJTY6ow=="
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
       }
     },
@@ -579,8 +384,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -665,7 +469,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -911,8 +714,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2556,7 +2358,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/textlint/package.json
+++ b/textlint/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@taichi/vscode-textlint-server": "file:../textlint-server",
+    "minimatch": "^3.0.4",
     "vscode-languageclient": "^5.2.1",
     "vscode-uri": "^1.0.1"
   },
@@ -109,6 +110,11 @@
           ],
           "default": "off",
           "description": "Traces the communication between VSCode and the textlint linter service."
+        },
+        "textlint.targetPath": {
+          "type": "string",
+          "default": "",
+          "description": "Target files path that runs lint."
         }
       }
     },

--- a/textlint/src/extension.ts
+++ b/textlint/src/extension.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
+import * as minimatch from "minimatch";
 
 import {
     workspace, window, commands, ExtensionContext, Disposable, TextDocumentSaveReason, TextEditor
@@ -162,7 +163,14 @@ function configureAutoFixOnSave(client: LanguageClient) {
         let languages = new Set(SUPPORT_LANGUAGES);
         autoFixOnSave = workspace.onWillSaveTextDocument(event => {
             let doc = event.document;
-            if (languages.has(doc.languageId) && event.reason !== TextDocumentSaveReason.AfterDelay) {
+            let target = getConfig("targetPath", null);
+            if (
+                languages.has(doc.languageId) &&
+                event.reason !== TextDocumentSaveReason.AfterDelay &&
+                (target === "" || minimatch(doc.fileName.replace(workspace.rootPath + "/", ""), target, {
+                    matchBase: true
+                }))
+            ) {
                 let version = doc.version;
                 let uri: string = doc.uri.toString();
                 event.waitUntil(


### PR DESCRIPTION
Hi, I added a feature that sets a target path(a target path support a glob format).
This is because the file I want to apply textlint to is not all files in the workspace.

example is below:
![a](https://user-images.githubusercontent.com/2158863/65813759-48327380-e214-11e9-8a8a-03ee20b37f1c.gif)

If you would like, you can review this.
