### PR TITLE
Add option to choose languages and improve positioning of highlighted…

### DIFF
--- a/textlint-server/src/server.ts
+++ b/textlint-server/src/server.ts
@@ -224,12 +224,20 @@ function toDiagnosticSeverity(severity?: number): DiagnosticSeverity {
 
 function toDiagnostic(message: TextLintMessage): [TextLintMessage, Diagnostic] {
     let txt = message.ruleId ? `${message.message} (${message.ruleId})` : message.message;
-    let pos = Position.create(Math.max(0, message.line - 1), Math.max(0, message.column - 1));
+    let pos_start = Position.create(Math.max(0, message.line - 1), Math.max(0, message.column - 1));
+    var offset = 0;
+    if (message.message.indexOf('->') >= 0) {
+        offset = message.message.indexOf(' ->');
+    }
+    if (message.message.indexOf('"') >= 0) {
+        offset = message.message.indexOf('"', message.message.indexOf('"') + 1) - 1;
+    }
+    let pos_end = Position.create(Math.max(0, message.line - 1), Math.max(0, message.column - 1) + offset);;
     let diag: Diagnostic = {
         message: txt,
         severity: toDiagnosticSeverity(message.severity),
         source: "textlint",
-        range: Range.create(pos, pos),
+        range: Range.create(pos_start, pos_end),
         code: message.ruleId
     };
     return [message, diag];

--- a/textlint-server/src/types.ts
+++ b/textlint-server/src/types.ts
@@ -2,7 +2,6 @@
 import { NotificationType0, NotificationType, RequestType } from "vscode-jsonrpc";
 import { TextDocumentIdentifier, TextEdit } from "vscode-languageserver-types";
 
-export const SUPPORT_LANGUAGES = ["plaintext", "markdown", "html", "tex", "latex", "doctex"];
 
 export namespace ExitNotification {
     export interface ExitParams {

--- a/textlint/package.json
+++ b/textlint/package.json
@@ -59,12 +59,16 @@
     "vscode": "^1.38.0"
   },
   "activationEvents": [
+    "onLanguage:html",
     "onLanguage:plaintext",
     "onLanguage:markdown",
-    "onLanguage:html",
-    "onLanguage:tex",
     "onLanguage:latex",
+    "onLanguage:tex",
+    "onLanguage:pdf",
+    "onLanguage:django-txt",
+    "onLanguage:django-html",
     "onLanguage:doctex",
+    "onLanguage:restructuredtext",
     "onCommand:textlint.showOutputChannel",
     "onCommand:textlint.createConfig",
     "onCommand:textlint.executeAutofix"
@@ -77,6 +81,18 @@
       "type": "object",
       "title": "textlint",
       "properties": {
+        "textlint.languages": {
+          "default": [
+            ["markdown", "plaintext"]
+          ],
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Languages to lint with textlint."
+        },
         "textlint.configPath": {
           "type": "string",
           "default": null,

--- a/textlint/src/extension.ts
+++ b/textlint/src/extension.ts
@@ -16,7 +16,6 @@ import {
 import { LogTraceNotification } from "vscode-jsonrpc";
 
 import {
-    SUPPORT_LANGUAGES,
     StatusNotification, NoConfigNotification, NoLibraryNotification, ExitNotification, AllFixesRequest,
     StartProgressNotification, StopProgressNotification
 } from "./types";
@@ -31,7 +30,7 @@ export interface ExtensionInternal {
 
 export function activate(context: ExtensionContext): ExtensionInternal {
     let client = newClient(context);
-    let statusBar = new StatusBar(SUPPORT_LANGUAGES);
+    let statusBar = new StatusBar(getConfig("languages"));
     client.onReady().then(() => {
         client.onDidChangeState(event => {
             statusBar.serverRunning = event.newState === ServerState.Running;
@@ -90,7 +89,7 @@ function newClient(context: ExtensionContext): LanguageClient {
     };
 
     let defaultErrorHandler: ErrorHandler;
-    let languages = SUPPORT_LANGUAGES.map(id => {
+    let languages = getConfig("languages").map(id => {
         return { language: id, scheme: 'file' };
     });
     let serverCalledProcessExit = false;
@@ -160,7 +159,7 @@ let autoFixOnSave: Disposable;
 function configureAutoFixOnSave(client: LanguageClient) {
     let auto = getConfig("autoFixOnSave", false);
     if (auto && !autoFixOnSave) {
-        let languages = new Set(SUPPORT_LANGUAGES);
+        let languages = new Set(getConfig("languages"));
         autoFixOnSave = workspace.onWillSaveTextDocument(event => {
             let doc = event.document;
             let target = getConfig("targetPath", null);

--- a/textlint/src/types.ts
+++ b/textlint/src/types.ts
@@ -2,7 +2,6 @@
 import { NotificationType0, NotificationType, RequestType } from "vscode-jsonrpc";
 import { TextDocumentIdentifier, TextEdit } from "vscode-languageserver-types";
 
-export const SUPPORT_LANGUAGES = ["plaintext", "markdown", "html", "tex", "latex", "doctex"];
 
 export namespace ExitNotification {
     export interface ExitParams {


### PR DESCRIPTION
… text

I'd like to suggest a pull request. There are 2 main changes:

1) I suggest letting users choose which languages they want to use textlint for. I have the default as `plaintext` and `markdown`, but a user can define `textlint.languages` themselves.

2) Sometimes only one word is highlighted even though it's a combination of words that are problematic. I updated the positioning code to allow for this.