### PR TITLE
Add .textlintignore support

### DIFF
--- a/textlint/README.md
+++ b/textlint/README.md
@@ -27,6 +27,9 @@ command `Create '.textlintrc' file`.
 * `textlint.configPath`
   * absolute path to textlint config file.
   * workspace settings are prioritize.
+* `textlint.ignorePath`
+  * absolute path to textlint ignore file.
+  * see [here](https://textlint.github.io/docs/ignore.html#ignoring-files-textlintignore) for ignore file.
 * `textlint.targetPath`
   * set a glob pattern.
 

--- a/textlint/package.json
+++ b/textlint/package.json
@@ -102,6 +102,11 @@
           "default": null,
           "description": "A absolute path to textlint config file."
         },
+        "textlint.ignorePath": {
+          "type": "string",
+          "default": null,
+          "description": "A absolute path to textlint ignore file."
+        },
         "textlint.nodePath": {
           "type": "string",
           "default": null,

--- a/textlint/src/extension.ts
+++ b/textlint/src/extension.ts
@@ -102,12 +102,14 @@ function newClient(context: ExtensionContext): LanguageClient {
             fileEvents: [
                 workspace.createFileSystemWatcher("**/package.json"),
                 workspace.createFileSystemWatcher('**/.textlintrc'),
-                workspace.createFileSystemWatcher('**/.textlintrc.{js,json,yml,yaml}')
+                workspace.createFileSystemWatcher('**/.textlintrc.{js,json,yml,yaml}'),
+                workspace.createFileSystemWatcher('**/.textlintignore')
             ]
         },
         initializationOptions: () => {
             return {
                 configPath: getConfig("configPath"),
+                ignorePath: getConfig("ignorePath"),
                 nodePath: getConfig("nodePath"),
                 run: getConfig("run"),
                 trace: getConfig("trace", "off")


### PR DESCRIPTION
https://textlint.github.io/docs/ignore.html#ignoring-files-textlintignore

I implemented [the same ignore logic as textlint](https://github.com/textlint/textlint/blob/textlint%4011.9.0/packages/textlint/src/util/find-util.ts#L47-L91) because `TextLintEngine.executeOnText()` does not consider ignore file.

Close #20.