### PR TITLE
Fix highlight range issue

### DIFF
--- a/packages/textlint-server/src/server.ts
+++ b/packages/textlint-server/src/server.ts
@@ -322,10 +322,9 @@ function toDiagnostic(message: TextLintMessage): [TextLintMessage, Diagnostic] {
   if (message.message.indexOf("->") >= 0) {
     offset = message.message.indexOf(" ->");
   }
-  // eslint-disable-next-line quotes
-  if (message.message.indexOf('"') >= 0) {
-    // eslint-disable-next-line quotes
-    offset = message.message.indexOf('"', message.message.indexOf('"') + 1) - 1;
+  const quoteIndex = message.message.indexOf(`"`);
+  if (quoteIndex >= 0) {
+    offset = Math.max(0, message.message.indexOf(`"`, quoteIndex + 1) - quoteIndex - 1);
   }
   const pos_end = Position.create(Math.max(0, message.line - 1), Math.max(0, message.column - 1) + offset);
   const diag: Diagnostic = {


### PR DESCRIPTION
Thank you for developing such a cool extension.

By the way, I realized the highlight range is sometimes corrupted. 
After some investigation, it seems that the offset is wrong if the message from textlint is as follows:
`【dict5】 "検証を行う"は冗長な表現です。"検証する"など簡潔な表現にすると文章が明瞭になります。\n解説: https://github.com/textlint-ja/textlint-rule-ja-no-redundant-expression#dict5 (ja-technical-writing/ja-no-redundant-expression)`

I expected  "A の検証を行い" to be highlighted but "A の検証を行い、本文章では B" is highlighted.

This extension parses the textlint message as follows:
`"range":{"start":{"line":0,"character":3},"end":{"line":0,"character":16}}`

The start character position is corrected, but the end character position is wrong.
This case occurs if the message doesn't start with `"`.

So, I created this PR, but this is not a perfect fix because we don't know the exact length of the characters that need to be corrected.
But I think that this PR will mitigate the problem.

## Screenshot
### Before
<img width="1000" alt="Screen Shot 2021-11-30 at 14 19 32" src="https://user-images.githubusercontent.com/10101661/143994433-8887a9df-2004-4788-a09c-64cb910f1584.png">

### After
<img width="1000" alt="Screen Shot 2021-11-30 at 14 37 24" src="https://user-images.githubusercontent.com/10101661/143994441-19553711-02c0-4cea-9122-0b72b5651572.png">