### PR TITLE
fix: use Status.WARN instead of ERROR

### DIFF
--- a/packages/textlint/src/extension.ts
+++ b/packages/textlint/src/extension.ts
@@ -67,7 +67,7 @@ File will not be validated. Consider running the 'Create .textlintrc file' comma
       );
     });
     client.onNotification(NoLibraryNotification.type, (p) => {
-      statusBar.status = Status.ERROR;
+      statusBar.status = Status.WARN;
       statusBar.status.log(
         client,
         `Failed to load the textlint library in ${p.workspaceFolder} .


### PR DESCRIPTION
If ERROR is set to ERROR, the OUTPUT panel opens, so use WARNING instead.

This PR changes the behaviour when opening a project without textlint installed.

## BEFORE

<img width="1624" alt="image" src="https://github.com/taichi/vscode-textlint/assets/19714/5e695041-da31-488d-87df-6fe7cd49acf8">


## AFTER

<img width="1624" alt="image" src="https://github.com/taichi/vscode-textlint/assets/19714/77facb02-2e2d-4260-9887-fa1741c9fa14">

fix #66 
cc @taichi 