### PR TITLE
Fix "Enable to emit activation events on all language files"

### DIFF
--- a/packages/test/.textlintrc
+++ b/packages/test/.textlintrc
@@ -1,6 +1,10 @@
 {
   "plugins": {
-    "html": true,
+    "html": {
+      "extensions": [
+        ".js"
+      ]
+    },
     "latex2e": true
   },
   "filters": {},

--- a/packages/test/.vscode/settings.json
+++ b/packages/test/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
     "textlint.run": "onType",
     "textlint.autoFixOnSave": false,
-    "textlint.trace": "verbose"
+    "textlint.trace": "verbose",
+    "textlint.languages": [
+        "markdown",
+        "plaintext",
+        "html",
+        "tex",
+        "latex",
+        "doctex",
+        "javascript"
+    ]
 }

--- a/packages/test/testtest.js
+++ b/packages/test/testtest.js
@@ -1,0 +1,1 @@
+// TODO: This is a validated target.

--- a/packages/test/testtest.py
+++ b/packages/test/testtest.py
@@ -1,0 +1,1 @@
+# TODO: This is NOT a validated target.

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -115,16 +115,7 @@
     }
   },
   "activationEvents": [
-    "onLanguage:html",
-    "onLanguage:plaintext",
-    "onLanguage:markdown",
-    "onLanguage:latex",
-    "onLanguage:tex",
-    "onLanguage:pdf",
-    "onLanguage:django-txt",
-    "onLanguage:django-html",
-    "onLanguage:doctex",
-    "onLanguage:restructuredtext",
+    "onLanguage",
     "onCommand:textlint.showOutputChannel",
     "onCommand:textlint.createConfig",
     "onCommand:textlint.executeAutofix"
@@ -151,7 +142,7 @@
     "webpack-cli": "^4.9.1"
   },
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.74.0"
   },
   "icon": "textlint-icon_128x128.png",
   "galleryBanner": {

--- a/packages/textlint/src/extension.ts
+++ b/packages/textlint/src/extension.ts
@@ -238,7 +238,7 @@ function configureAutoFixOnSave(client: LanguageClient) {
   disposeAutoFixOnSave();
 
   if (auto) {
-    const languages = new Set(getConfig("languages"));
+    const languages = new Set(getConfig<string[]>("languages", []));
     autoFixOnSave = workspace.onWillSaveTextDocument((event) => {
       const doc = event.document;
       const target = getConfig("targetPath", null);

--- a/packages/textlint/src/status.ts
+++ b/packages/textlint/src/status.ts
@@ -57,6 +57,20 @@ export class StatusBar {
       this._delegate.hide();
     }
   }
+  activate(languageId: string) {
+    if (languageId === "") {
+      return;
+    }
+
+    if (-1 !== this._supports.indexOf(languageId)) {
+      this._delegate.color = "";
+      this._delegate.tooltip =
+        "need to restart this extension or check this extension setting and .textlintrc if textlint is not working.";
+    } else {
+      this._delegate.color = "#818589";
+      this._delegate.tooltip = `textlint is inanctive on ${languageId}.`;
+    }
+  }
 
   get status(): Status {
     return this._status;
@@ -73,7 +87,7 @@ export class StatusBar {
 
   set serverRunning(sr: boolean) {
     this._serverRunning = sr;
-    this._delegate.tooltip = sr ? "textlint server is running." : "textlint server stopped.";
+    window.showInformationMessage(sr ? "textlint server is running." : "textlint server stopped.");
     this.update();
   }
 
@@ -83,11 +97,9 @@ export class StatusBar {
 
   updateWith(editor: TextEditor) {
     this._delegate.text = this.status.label;
-    this.show(
-      this.serverRunning === false ||
-        this._status !== Status.OK ||
-        (editor && 0 < this._supports.indexOf(editor.document.languageId))
-    );
+    const languageId = editor?.document.languageId ?? "";
+    this.activate(languageId);
+    this.show(this.serverRunning === false || this._status !== Status.OK || -1 !== this._supports.indexOf(languageId));
   }
 
   startProgress() {


### PR DESCRIPTION
Allow to emit activate events on user's selected language files of all.
and, You can see whether or not a file in active editor is textlint target.
![image](https://github.com/taichi/vscode-textlint/assets/51286326/5f848492-84b0-4c46-94b0-69671c2f665f)


![image](https://github.com/taichi/vscode-textlint/assets/51286326/926fdb53-00dc-4d66-9bb1-a8dd2df17d91)

![image](https://github.com/taichi/vscode-textlint/assets/51286326/3f192244-a54c-4db8-ae4a-def1b46bd08b)

fix #69
cc. @taichi 